### PR TITLE
add custom pod labels and annotations support

### DIFF
--- a/charts/burrow/Chart.yaml
+++ b/charts/burrow/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.3.3"
 description: A Helm chart for Kubernetes
 name: burrow
-version: 0.1.7
+version: 0.1.8
 icon: https://media.licdn.com/dms/image/C4D0BAQEj-Fx1qtIAKQ/company-logo_200_200/0?e=2159024400&v=beta&t=90Cva_S5-k44uPf_P11ZdHQ6WnUCjuSrTGQshbTvWVo

--- a/charts/burrow/templates/burrow-deployment.yaml
+++ b/charts/burrow/templates/burrow-deployment.yaml
@@ -19,7 +19,13 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/burrow-configmap.yaml") . | sha256sum }}
         checksum/templates: {{ include (print $.Template.BasePath "/burrow-templates-configmap.yaml") . | sha256sum }}
+        {{- with .Values.burrow.podAnnotations }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       labels:
+        {{- with .Values.burrow.podLabels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         app.kubernetes.io/name: {{ include "burrow.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:

--- a/charts/burrow/values.yaml
+++ b/charts/burrow/values.yaml
@@ -16,6 +16,8 @@ fullnameOverride: ""
 burrow:
   labels: {}
   annotations: {}
+  podLabels: {}
+  podAnnotations: {}
 
   ## Secret containing configuration environment variables
   ## For example enviroment variable: BURROW_ZOOKEEPER_SERVERS - will set Zookeeper servers for Burrow


### PR DESCRIPTION
This change adds the possibility to specify custom labels and annotations for burrow pods.