### PR TITLE
Add client-profile for Burrow cluster section config

### DIFF
--- a/charts/burrow/Chart.yaml
+++ b/charts/burrow/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.3.3"
 description: A Helm chart for Kubernetes
 name: burrow
-version: 0.1.8
+version: 0.1.9
 icon: https://media.licdn.com/dms/image/C4D0BAQEj-Fx1qtIAKQ/company-logo_200_200/0?e=2159024400&v=beta&t=90Cva_S5-k44uPf_P11ZdHQ6WnUCjuSrTGQshbTvWVo

--- a/charts/burrow/templates/burrow-configmap.yaml
+++ b/charts/burrow/templates/burrow-configmap.yaml
@@ -55,6 +55,7 @@ data:
     [cluster.{{ default $key }}]
     class-name={{ $value.className | default "kafka" | quote }}
     servers={{ include "burrow.servers" $value.servers }}
+    client-profile={{ with $value.clientProfile }}{{ . | quote }}{{ end }}
     topic-refresh={{ $value.topicRefresh | default 60 }}
     offset-refresh={{ $value.offsetRefresh | default 10 }}
     {{ end }}


### PR DESCRIPTION
This change implements the possibility to specify client-profile in cluster section of Burrow configuration.