### PR TITLE
fix indentation for pod labels/annotations

### DIFF
--- a/charts/burrow/Chart.yaml
+++ b/charts/burrow/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.3.3"
 description: A Helm chart for Kubernetes
 name: burrow
-version: 0.1.9
+version: 0.1.10
 icon: https://media.licdn.com/dms/image/C4D0BAQEj-Fx1qtIAKQ/company-logo_200_200/0?e=2159024400&v=beta&t=90Cva_S5-k44uPf_P11ZdHQ6WnUCjuSrTGQshbTvWVo

--- a/charts/burrow/templates/burrow-deployment.yaml
+++ b/charts/burrow/templates/burrow-deployment.yaml
@@ -20,11 +20,11 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/burrow-configmap.yaml") . | sha256sum }}
         checksum/templates: {{ include (print $.Template.BasePath "/burrow-templates-configmap.yaml") . | sha256sum }}
         {{- with .Values.burrow.podAnnotations }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         {{- with .Values.burrow.podLabels }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         app.kubernetes.io/name: {{ include "burrow.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Wrong indentation was put with introducing pod labels/annotations support.
This fixes the bug.