### PR TITLE
Add configuration for Node affinity in monochart

### DIFF
--- a/charts/monochart/templates/deployment.yaml
+++ b/charts/monochart/templates/deployment.yaml
@@ -79,6 +79,16 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
 {{- end }}
+{{- if .Values.deployment.affinity.nodeAffinity }}      
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+{{- if .Values.deployment.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms }}            
+{{- with .Values.deployment.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms }}
+{{ toYaml . | indent 16 }}
+{{- end }}
+{{- end }}  
+{{- end }} 
 {{- end }}
 {{- with .Values.deployment.tolerations }}
       tolerations:

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -98,6 +98,14 @@ deployment:
                 values:
                   - "postgresql"
           topologyKey: "kubernetes.io/hostname"
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: Name
+            operator: In
+            values:
+            - va-verity-eks--stage-vng-public          
 
 service:
   enabled: true


### PR DESCRIPTION
This is the output:

```yaml
NAME: test
LAST DEPLOYED: Thu Jun  1 18:41:14 2023
NAMESPACE: default
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: monochart/templates/crd.yaml
apiVersion: "v1"
kind: "ServiceAccount"
metadata:
  name: test-monochart-default
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
spec:
  null
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-env-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
type: Opaque
data:
  SECRET_ENV_NAME: RU5WX1ZBTFVF
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-files-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
type: Opaque
data:
  secret.test.txt: c29tZSB0ZXh0
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-env-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
data:
  CONFIG_ENV_NAME: ENV_VALUE
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-files-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
data:
  config.test.txt: |
    some text
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-monochart
  annotations:
    nginx.version: 1.15.3
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    component: nginx
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  minReadySeconds: 10
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 7a7544f46ad0c5336bde5c68c275b894233b51b72b47ad5d5d0feb755d940bf3
        checksum/secret: 983b4ef4da1aee3e078ee3a0f6573382531337f4f0b39163166aaffba040c7e1
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - monochart
                - key: release
                  operator: In
                  values:
                  - "test"
              topologyKey: "kubernetes.io/hostname"
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: NotIn
                values:
                - postgresql
              - key: release
                operator: NotIn
                values:
                - postgresql
            topologyKey: kubernetes.io/hostname      
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        env:
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        lifecycle:
          preStop:
            exec:
              command:
              - sh
              - -c
              - sleep 60
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
---
# Source: monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: monochart
    chart: monochart-0.27.0
    heritage: "Helm"
    release: "test"
    ingressName: default
  name: test-monochart-default
spec:
  rules:
    - host: testme.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name:  test-monochart
                port:
                  name: http

NOTES:
Thank you for installing monochart.

Your release is named test.
```