### PR TITLE
Add security context configuration

### DIFF
--- a/charts/monochart/Chart.yaml
+++ b/charts/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.28.0
-appVersion: 0.28.0
+version: 0.29.0
+appVersion: 0.29.0
 home: https://github.com/Lowess/charts/tree/master/charts/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/charts/monochart/templates/deployment.yaml
+++ b/charts/monochart/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.deployment.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -81,6 +81,10 @@ deployment:
       operator: "Equal"
       value: "custom-vng"
       effect: "NoSchedule"
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000        
   affinity:
     # use of simple rule
     affinityRule: "ShouldBeOnDifferentNode"


### PR DESCRIPTION
This is the output for the test:

```
NAME: test
LAST DEPLOYED: Thu Jun 15 11:03:56 2023
NAMESPACE: default
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: monochart/templates/crd.yaml
apiVersion: "v1"
kind: "ServiceAccount"
metadata:
  name: test-monochart-default
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
spec:
  null
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-env-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
type: Opaque
data:
  SECRET_ENV_NAME: RU5WX1ZBTFVF
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-files-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
type: Opaque
data:
  secret.test.txt: c29tZSB0ZXh0
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-env-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
data:
  CONFIG_ENV_NAME: ENV_VALUE
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-files-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
data:
  config.test.txt: |
    some text
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-monochart
  annotations:
    nginx.version: 1.15.3
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    component: nginx
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  minReadySeconds: 10
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 7f5e776b976d293079446ad5b1c581d66ee35b3418b4b5c2531ac0d50939c4ab
        checksum/secret: a6a1d2ef3de84ad861a029bbfce8684ebd079138d4469ca31f367d5dcb8b9a7f
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - monochart
                - key: release
                  operator: In
                  values:
                  - "test"
              topologyKey: "kubernetes.io/hostname"
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: NotIn
                values:
                - postgresql
              - key: release
                operator: NotIn
                values:
                - postgresql
            topologyKey: kubernetes.io/hostname      
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng
      securityContext:
        fsGroup: 2000
        runAsGroup: 3000
        runAsUser: 1000
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        env:
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        lifecycle:
          preStop:
            exec:
              command:
              - sh
              - -c
              - sleep 60
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
---
# Source: monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: monochart
    chart: monochart-0.28.0
    heritage: "Helm"
    release: "test"
    ingressName: default
  name: test-monochart-default
spec:
  rules:
    - host: testme.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name:  test-monochart
                port:
                  name: http

NOTES:
Thank you for installing monochart.

Your release is named test.
```