### PR TITLE
Add config for security Context in statefulset

### DIFF
--- a/charts/monochart/Chart.yaml
+++ b/charts/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 home: https://github.com/Lowess/charts/tree/master/charts/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/charts/monochart/templates/statefulset.yaml
+++ b/charts/monochart/templates/statefulset.yaml
@@ -42,6 +42,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+{{- with .Values.statefulset.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}  
+{{- end }}
 {{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -194,3 +194,20 @@ crd:
       default:
         enabled: true
         annotations: {}
+
+dockercfg:
+  enabled: false   
+
+statefulset:
+  enabled: true
+  persistence:
+    enabled: true
+    useVolumeClaimTemplates: true
+    mountPath: /tmp
+    accessMode: ReadWriteOnce
+    size: 30Gi
+    storageClass: gp3
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000   


### PR DESCRIPTION
I couldn't generate the template as usual, I was getting this:

`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "test-monochart" namespace: "" from "": no matches for kind "Rollout" in version "argoproj.io/v1alpha1"`

 I'm doing pretty much the same as with the deployments template.