### PR TITLE
Add statefulset configuration

### DIFF
--- a/charts/monochart/Chart.yaml
+++ b/charts/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.0.2
+appVersion: 1.0.2
 home: https://github.com/Lowess/charts/tree/master/charts/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/charts/monochart/templates/statefulset.yaml
+++ b/charts/monochart/templates/statefulset.yaml
@@ -50,6 +50,10 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
+{{- with .Values.statefulset.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 10 }}
+{{- end }}      
 {{- if .Values.statefulset.affinity }}
       affinity:
 {{- if or .Values.statefulset.affinity.podAntiAffinity (eq .Values.statefulset.affinity.affinityRule "ShouldBeOnDifferentNode") }}
@@ -73,6 +77,22 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+
+{{- if .Values.statefulset.affinity.nodeAffinity }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+{{- if .Values.statefulset.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms }}
+{{- with .Values.statefulset.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms }}
+{{ toYaml . | indent 16 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with .Values.statefulset.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
 {{- end }}
       containers:
       - name: {{ .Release.Name }}

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -168,7 +168,19 @@ statefulset:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
-
+  dnsConfig:
+    options:
+      - name: ndots
+        value: "1"
+  affinity:        
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: Name
+            operator: In
+            values:
+            - va-verity-eks--stage-vng-public        
 
 service:
   default:


### PR DESCRIPTION
The output:

```
NAME: test
LAST DEPLOYED: Mon Jun 26 09:47:39 2023
NAMESPACE: monitoring
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: monochart/templates/crd.yaml
apiVersion: "v1"
kind: "ServiceAccount"
metadata:
  name: test-monochart-default
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
spec:
  null
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-env-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
type: Opaque
data:
  SECRET_ENV_NAME: RU5WX1ZBTFVF
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-files-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
type: Opaque
data:
  secret.test.txt: c29tZSB0ZXh0
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-env-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
data:
  CONFIG_ENV_NAME: ENV_VALUE
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-files-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
data:
  config.test.txt: |
    some text
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-canary
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-stable
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-monochart
  annotations:
    nginx.version: 1.15.3
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    component: nginx
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  minReadySeconds: 10
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 682b3e855345635e2a8abb63a4d5e7d4f1864951d9b85e8b6453bb6a1128d38e
        checksum/secret: b51547ba8ea61754971164c5a3ea9c148fa1162bd0f1edaecc2aa868bd379df4
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - monochart
                - key: release
                  operator: In
                  values:
                  - "test"
              topologyKey: "kubernetes.io/hostname"
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: NotIn
                values:
                - postgresql
              - key: release
                operator: NotIn
                values:
                - postgresql
            topologyKey: kubernetes.io/hostname
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng
      securityContext:
        fsGroup: 2000
        runAsGroup: 3000
        runAsUser: 1000
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        env:
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        lifecycle:
          preStop:
            exec:
              command:
              - sh
              - -c
              - sleep 60

        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
---
# Source: monochart/templates/statefulset.yaml
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  serviceName: test-monochart
  replicas: 
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 682b3e855345635e2a8abb63a4d5e7d4f1864951d9b85e8b6453bb6a1128d38e
        checksum/secret: b51547ba8ea61754971164c5a3ea9c148fa1162bd0f1edaecc2aa868bd379df4
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsUser: 1000
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 10
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng





      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        env:
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        

        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: "/tmp"
          name: test-monochart
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
  volumeClaimTemplates:
  - metadata:
      name: test-monochart
      labels:
        app: monochart
        chart: monochart-1.0.1
        heritage: "Helm"
        release: "test"
    spec:
      accessModes:
        - "ReadWriteOnce"
      resources:
        requests:
          storage: "30Gi"
      storageClassName: "gp3"
---
# Source: monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: monochart
    chart: monochart-1.0.1
    heritage: "Helm"
    release: "test"
    ingressName: default
  name: test-monochart-default
spec:
  rules:
    - host: testme.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name:  test-monochart
                port:
                  name: http

NOTES:
Thank you for installing monochart.

Your release is named test.
```