### PR TITLE
Add configuration for ephemeral storage

### DIFF
--- a/charts/monochart/Chart.yaml
+++ b/charts/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 1.0.7
-appVersion: 1.0.7
+version: 1.0.8
+appVersion: 1.0.8
 home: https://github.com/Lowess/charts/tree/master/charts/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/charts/monochart/templates/deployment.yaml
+++ b/charts/monochart/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       release: {{ .Release.Name }}
 {{- if .Values.deployment.labels }}
       type: {{ .Values.deployment.labels.type | default (include "common.name" .)  }}
-{{- end }}      
+{{- end }}
 {{- with .Values.deployment.strategy }}
   strategy:
 {{ toYaml . | indent 4 }}
@@ -46,7 +46,7 @@ spec:
         serve: "true"
 {{- if .Values.deployment.labels }}
         type: {{ .Values.deployment.labels.type | default (include "common.name" .)  }}
-{{- end }}         
+{{- end }}
 {{- if .Values.deployment.pod}}
 {{- with .Values.deployment.pod.labels }}
 {{ toYaml .| indent 8 }}
@@ -55,10 +55,10 @@ spec:
     spec:
 {{- if .Values.deployment.topologySpreadConstraints }}
 {{- with .Values.deployment.topologySpreadConstraints }}
-      topologySpreadConstraints: 
-{{ toYaml . | indent 8 }}      
-{{- end }}            
-{{- end }}    
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}
 {{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
@@ -154,6 +154,9 @@ spec:
         {{- if .Values.persistence.enabled }}
         - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
+        {{- else if .Values.deployment.ephemeral.enabled }}
+        - mountPath: {{ .Values.deployment.ephemeral.mountPath | quote }}
+          name: scratch
         {{- end }}
         {{- include "monochart.files.volumeMounts" . |  nindent 8 }}
         {{- end }}
@@ -178,6 +181,20 @@ spec:
       volumes:
       {{- if .Values.deployment.volumes }}
         {{- toYaml .Values.deployment.volumes | nindent 6 }}
+      {{- end }}
+      {{- if .Values.deployment.ephemeral.enabled }}
+      - name: scratch
+        ephemeral:
+          volumeClaimTemplate:
+            metadata:
+              labels:
+                type: {{ include "common.name" . }}
+            spec:
+              accessModes: [ {{ .Values.deployment.ephemeral.accessMode | quote }} ]
+              storageClassName: {{ .Values.deployment.ephemeral.storageClassName | quote }}
+              resources:
+                requests:
+                  storage: {{ .Values.deployment.ephemeral.size }}
       {{- end }}
       {{- if .Values.persistence.enabled }}
       - name: storage

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -64,7 +64,14 @@ deployment:
   annotations:
     nginx.version: 1.15.3
   labels:
-    component: nginx    
+    component: nginx
+  ephemeral:
+    enabled: true
+    accessMode: ReadWriteOnce
+    mountPath: /tmp
+    storageClassName: scratch-storage-class
+    size: 8Gi
+
   pod:
     annotations: {}
     ## https://github.com/uswitch/kiam
@@ -90,7 +97,7 @@ deployment:
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          app: nginx-test          
+          app: nginx-test
   tolerations:
     - key: "spotinst.io/pool"
       operator: "Equal"
@@ -188,7 +195,7 @@ statefulset:
       - name: ndots
         value: "1"
   podManagementPolicy: "Parallel"
-  affinity:        
+  affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
@@ -196,7 +203,7 @@ statefulset:
           - key: Name
             operator: In
             values:
-            - va-verity-eks--stage-vng-public        
+            - va-verity-eks--stage-vng-public
 
 service:
   default:


### PR DESCRIPTION
```
Output:

NAME: test
LAST DEPLOYED: Tue Sep 19 17:52:52 2023
NAMESPACE: video-pipeline
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: monochart/templates/crd.yaml
apiVersion: "v1"
kind: "ServiceAccount"
metadata:
  name: test-monochart-default
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
spec:
  null
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-env-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
type: Opaque
data:
  SECRET_ENV_NAME: RU5WX1ZBTFVF
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-files-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
type: Opaque
data:
  secret.test.txt: c29tZSB0ZXh0
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-env-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
data:
  CONFIG_ENV_NAME: ENV_VALUE
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-files-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
data:
  config.test.txt: |
    some text
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-canary
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-stable
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-monochart
  annotations:
    nginx.version: 1.15.3
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    component: nginx
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
      type: monochart
  minReadySeconds: 10
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 36f2dbc283057ecf760026847960465d0b36ff9cce304c94533b4304a032bdac
        checksum/secret: f45417a3fe5a8e325b5a0c15d0b9606b55e3575d27f2ebc81c86f5c19f87efb2
      labels:
        app: monochart
        release: "test"
        serve: "true"
        type: monochart
    spec:
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app: nginx-test
          maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: ScheduleAnyway
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - monochart
                - key: release
                  operator: In
                  values:
                  - "test"
              topologyKey: "kubernetes.io/hostname"
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: NotIn
                values:
                - postgresql
              - key: release
                operator: NotIn
                values:
                - postgresql
            topologyKey: kubernetes.io/hostname
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng
      securityContext:
        fsGroup: 2000
        runAsGroup: 3000
        runAsUser: 1000
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        lifecycle:
          preStop:
            exec:
              command:
              - sh
              - -c
              - sleep 60
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: /var/run/datadog
          name: apmsocketpath
        - mountPath: "/tmp"
          name: scratch
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      - hostPath:
          path: /var/run/datadog/
        name: apmsocketpath
      - name: scratch
        ephemeral:
          volumeClaimTemplate:
            metadata:
              labels:
                type: monochart
            spec:
              accessModes: [ "ReadWriteOnce" ]
              storageClassName: "scratch-storage-class"
              resources:
                requests:
                  storage: 8Gi
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
---
# Source: monochart/templates/statefulset.yaml
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  serviceName: test-monochart  
  podManagementPolicy: Parallel
  replicas: 
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 36f2dbc283057ecf760026847960465d0b36ff9cce304c94533b4304a032bdac
        checksum/secret: f45417a3fe5a8e325b5a0c15d0b9606b55e3575d27f2ebc81c86f5c19f87efb2
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsUser: 1000
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 10
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: "/tmp"
          name: test-monochart
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
  volumeClaimTemplates:
  - metadata:
      name: test-monochart
      labels:
        app: monochart
        chart: monochart-1.0.8
        heritage: "Helm"
        release: "test"
    spec:
      accessModes:
        - "ReadWriteOnce"
      resources:
        requests:
          storage: "30Gi"
      storageClassName: "gp3"
---
# Source: monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: monochart
    chart: monochart-1.0.8
    heritage: "Helm"
    release: "test"
    ingressName: default
  name: test-monochart-default
spec:
  rules:
    - host: testme.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name:  test-monochart
                port:
                  name: http

NOTES:
------------------------------------
📦 monochart 1.0.8
└── 🌀 Namespace: video-pipeline
└── 🚀 Release:   test
└── 🐳 Container: nginx:1.15.3
└── 🌐 URL:       https://testme.com
------------------------------------

📚Manifests deployed:
│
├─ ✅Configmaps
│  └── ✅default
├─ ✅Crd
│  └── ✅Serviceaccount
│     └── ✅default
├─ ✅Deployment
├─ ✅Ingress
│  └── ✅default
├─ ✅Secrets
│  └── ✅default
├─ ✅Service
│  └── ✅canary
│  └── ✅default
│  └── ✅stable
├─ ✅Statefulset
```