### PR TITLE
Add support for ephemeral storage

### DIFF
--- a/charts/monochart/templates/deployment.yaml
+++ b/charts/monochart/templates/deployment.yaml
@@ -153,10 +153,7 @@ spec:
         {{- end }}
         {{- if .Values.persistence.enabled }}
         - mountPath: {{ .Values.persistence.mountPath | quote }}
-          name: storage
-        {{- else if .Values.deployment.ephemeral.enabled }}
-        - mountPath: {{ .Values.deployment.ephemeral.mountPath | quote }}
-          name: scratch
+          name: {{ .Values.persistence.storageName }}
         {{- end }}
         {{- include "monochart.files.volumeMounts" . |  nindent 8 }}
         {{- end }}
@@ -182,29 +179,29 @@ spec:
       {{- if .Values.deployment.volumes }}
         {{- toYaml .Values.deployment.volumes | nindent 6 }}
       {{- end }}
-      {{- if .Values.deployment.ephemeral.enabled }}
-      - name: scratch
+      {{- if .Values.persistence }}
+      {{- if .Values.persistence.enabled }}
+      - name: {{ .Values.persistence.storageName }}
+      {{- if and (hasKey .Values.persistence "ephemeral") .Values.persistence.ephemeral }}
         ephemeral:
           volumeClaimTemplate:
             metadata:
               labels:
                 type: {{ include "common.name" . }}
             spec:
-              accessModes: [ {{ .Values.deployment.ephemeral.accessMode | quote }} ]
-              storageClassName: {{ .Values.deployment.ephemeral.storageClassName | quote }}
+              accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
+              storageClassName: {{ .Values.persistence.storageClass | quote }}
               resources:
                 requests:
-                  storage: {{ .Values.deployment.ephemeral.size }}
-      {{- end }}
-      {{- if .Values.persistence.enabled }}
-      - name: storage
-      {{- if .Values.persistence.enabled }}
+                  storage: {{ .Values.persistence.size }}
+      {{- else }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
+      {{- end }}
       {{- else }}
         emptyDir: {}
       {{- end }}
       {{- end }}
-      {{- include "monochart.files.volumes" . | nindent 6 }}
       {{- end }}
+      {{- include "monochart.files.volumes" . | nindent 6 }}
 {{- end -}}

--- a/charts/monochart/templates/pvc.yaml
+++ b/charts/monochart/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.persistence -}}
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (not .Values.persistence.ephemeral)  -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -65,12 +65,6 @@ deployment:
     nginx.version: 1.15.3
   labels:
     component: nginx
-  ephemeral:
-    enabled: true
-    accessMode: ReadWriteOnce
-    mountPath: /tmp
-    storageClassName: scratch-storage-class
-    size: 8Gi
 
   pod:
     annotations: {}
@@ -131,7 +125,16 @@ deployment:
           - key: Name
             operator: In
             values:
-            - va-verity-eks--stage-vng-public
+            - custom-worker-group
+
+persistence:
+  enabled: true
+  storageName: ephemeral-storage
+  ephemeral: true
+  mountPath: /tmp
+  accessMode: ReadWriteOnce
+  size: 30Gi
+  storageClass: gp3
 
 rollout:
   enabled: false

--- a/charts/monochart/values.yaml
+++ b/charts/monochart/values.yaml
@@ -354,6 +354,7 @@ resources: {}
 ## Persistence and volumes
 persistence:
   enabled: false
+  ephemeral: false
   storageName: storage
   mountPath: /data
   accessMode: ReadWriteOnce


### PR DESCRIPTION
@sgcg10 here is a proposal to achieve ephemeral storage. This code change leverages the `.Values.persistence` object instead of introducing it in the deployment object (Because it really does the same in reality). I simply added the `ephemeral` attribute to it which will dictate if:
* The volume should be defined straight in the deployment object
* The volume should be a classic PVC

The reason I build it this way is because the proposed version you made in https://github.com/Lowess/helm-charts/pull/51/files was still breaking the `volumes:` section that is populated by the help function `{{- include "monochart.files.volumes" . | nindent 6 }}`

