### PR TITLE
Make chart compatible with Burrow v1.8.0

### DIFF
--- a/charts/burrow/Chart.yaml
+++ b/charts/burrow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.3.3
+appVersion: 1.8.0
 description: A Helm chart for Kubernetes
 icon: https://media.licdn.com/dms/image/C4D0BAQEj-Fx1qtIAKQ/company-logo_200_200/0?e=2159024400&v=beta&t=90Cva_S5-k44uPf_P11ZdHQ6WnUCjuSrTGQshbTvWVo
 name: burrow
-version: 0.1.12
+version: 0.2.0

--- a/charts/burrow/README.md
+++ b/charts/burrow/README.md
@@ -75,13 +75,13 @@ Parameter | Description | Default
 `burrow.config.consumer.<myclustername>.clusterName` | If `burrow.config.cluster.<myclustername>.clusterName` is set then this setting must be set to the same value |
 `burrow.config.consumer.<myclustername>.className` | This is the name of the cluster module type. The available classes are: `kafka` or `kafka_zk` | `kafka`
 `burrow.config.consumer.<myclustername>.servers` | A list of strings in the form "hostname:port" that point to the servers in the Kafka cluster. At least one is required |
-`burrow.config.consumer.<myclustername>.groupWhitelist` | If specified, only send offsets for groups that match this regular expression | `.*`
-`burrow.config.consumer.<myclustername>.groupBlacklist` | If specified, only send offsets for groups that DO NOT match this regular expression. This is processed after the whitelist (if specified) | `^.*(console-consumer-|python-kafka-consumer-).*`
+`burrow.config.consumer.<myclustername>.groupAllowlist` | If specified, only send offsets for groups that match this regular expression | `.*`
+`burrow.config.consumer.<myclustername>.groupDenylist` | If specified, only send offsets for groups that DO NOT match this regular expression. This is processed after the whitelist (if specified) | `^.*(console-consumer-|python-kafka-consumer-).*`
 `burrow.config.notifier.<mynotifier>.className` | This is the name of the cluster module type. The available classes are: `http` or `email` | `http`
 `burrow.config.notifier.<mynotifier>.interval` | The number of seconds to wait between sending notifications for a single group | `60`
 `burrow.config.notifier.<mynotifier>.threshold` | The minimum group status to send out notifications for (refer to [StatusConstant](https://godoc.org/github.com/linkedin/Burrow/core/protocol#StatusConstant) for values). | `1`
-`burrow.config.notifier.<mynotifier>.groupBlacklist` | If specified, only send notifications for groups that DO NOT match this regular expression. This is processed after the whitelist (if specified) | `^.*(console-consumer-|python-kafka-consumer-).*$`
-`burrow.config.notifier.<mynotifier>.groupWhitelist` | If specified, only send notifications for groups that match this regular expression | `^.*$`
+`burrow.config.notifier.<mynotifier>.groupDenylist` | If specified, only send notifications for groups that DO NOT match this regular expression. This is processed after the whitelist (if specified) | `^.*(console-consumer-|python-kafka-consumer-).*$`
+`burrow.config.notifier.<mynotifier>.groupAllowlist` | If specified, only send notifications for groups that match this regular expression | `^.*$`
 `burrow.config.notifier.<mynotifier>.extras` | A string representation of a JSON object that will be available when compiling the template for the message to send | `'{}'`
 `burrow.config.notifier.<mynotifier>.sendClose` | If `true`, use the template-close template to send a notification when the group status drops to OK (after it has been WARN or above) | `true`
 `burrow.config.notifier.<mynotifier>.urlOpen` | The URL to make a request to for groups that meet the threshold |

--- a/charts/burrow/templates/burrow-configmap.yaml
+++ b/charts/burrow/templates/burrow-configmap.yaml
@@ -65,8 +65,8 @@ data:
     class-name={{ $value.className | default "kafka" | quote }}
     cluster="{{ $value.clusterName | default $key }}"
     servers={{ include "burrow.servers" $value.servers }}
-    group-blacklist={{ $value.groupBlacklist | default "^.*(console-consumer-|python-kafka-consumer-).*$" | quote }}
-    group-whitelist={{ $value.groupWhitelist | default ".*" | quote }}
+    group-denylist={{ $value.groupDenylist | default "^.*(console-consumer-|python-kafka-consumer-).*$" | quote }}
+    group-allowlist={{ $value.groupAllowlist | default ".*" | quote }}
     start-latest={{ $value.startLatest | default false }}
     client-profile={{ with $value.clientProfile }}{{ . | quote }}{{ end }}
 
@@ -77,8 +77,8 @@ data:
     class-name={{ $value.className | default "http" | quote }}
     interval={{ $value.interval | default 60 }}
     threshold={{ $value.threshold | default 1 }}
-    group-blacklist={{ $value.groupBlacklist | default "^.*(console-consumer-|python-kafka-consumer-).*$" | quote }}
-    group-whitelist={{ $value.groupWhitelist | default "^.*$" | quote }}
+    group-denylist={{ $value.groupDenylist | default "^.*(console-consumer-|python-kafka-consumer-).*$" | quote }}
+    group-allowlist={{ $value.groupAllowlist | default "^.*$" | quote }}
     {{- if $value.extras }}
     extras={{ $value.extras }}
     {{- end }}

--- a/charts/burrow/values.yaml
+++ b/charts/burrow/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ifoodhub/burrow
-  tag: 1.3.3
+  tag: 1.8.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -88,8 +88,8 @@ burrow:
       #   className: http
       #   interval: 10
       #   threshold: 1
-      #   groupBlacklist: "^.*(console-consumer-|python-kafka-consumer-|DLT).*$"
-      #   groupWhitelist: ".*Verity-Stage$"
+      #   groupDenylist: "^.*(console-consumer-|python-kafka-consumer-|DLT).*$"
+      #   groupAllowlist: ".*Verity-Stage$"
       #   extras: '{ key1="value1", key2="value2" }'
       #   sendClose: true
       #   urlOpen: http://karrot.default.svc.cluster.local/burrow


### PR DESCRIPTION
Some parameters were renamed.

NOTE: not sure what to do with container image in values.yaml. 
Maybe we can leave it up to the person who uses chart to build container image and use it.