### PR TITLE
Update deployment template to allow requiredDuringSchedulingIgnoredDuringExecution in podAntiAffinity

### DIFF
--- a/charts/monochart/Chart.yaml
+++ b/charts/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 1.0.10
-appVersion: 1.0.10
+version: 1.0.11
+appVersion: 1.0.11
 home: https://github.com/Lowess/charts/tree/master/charts/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/charts/monochart/templates/deployment.yaml
+++ b/charts/monochart/templates/deployment.yaml
@@ -71,13 +71,10 @@ spec:
 {{- if .Values.deployment.affinity }}
       affinity:
 {{- if or .Values.deployment.affinity.podAntiAffinity (eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode") }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+        podAntiAffinity:        
 {{- if .Values.deployment.affinity.podAntiAffinity }}
-{{- if .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
-{{- with .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{- with .Values.deployment.affinity.podAntiAffinity }}
 {{ toYaml . | indent 10 }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode" }}

--- a/charts/monochart/values.example.yaml
+++ b/charts/monochart/values.example.yaml
@@ -118,6 +118,20 @@ deployment:
                 values:
                   - "postgresql"
           topologyKey: "kubernetes.io/hostname"
+    # podAntiAffinity to deploy one pod per node (Example for squid)
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              release: squid-proxy  
+          topologyKey: "kubernetes.io/hostname"
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                release: squid-proxy  # Match pods with this label
+            topologyKey: "kubernetes.io/hostname"  # Spread pods across nodes             
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:


### PR DESCRIPTION
The rendered template is:

```
NAME: test
LAST DEPLOYED: Thu Jan 23 15:31:53 2025
NAMESPACE: squid
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: monochart/templates/crd.yaml
apiVersion: "v1"
kind: "ServiceAccount"
metadata:
  name: test-monochart-default
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  null
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-env-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
type: Opaque
data:
  SECRET_ENV_NAME: RU5WX1ZBTFVF
---
# Source: monochart/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-monochart-files-default
  annotations:
    test.secret.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
type: Opaque
data:
  secret.test.txt: c29tZSB0ZXh0
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-env-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    component: env
    test_label: value
data:
  CONFIG_ENV_NAME: ENV_VALUE
---
# Source: monochart/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-monochart-files-default
  annotations:
    test.annotation: value
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    component: files
    test_label: value
data:
  config.test.txt: |
    some text
---
# Source: monochart/templates/storageclass.yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: efs-sc
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
provisioner: efs.csi.aws.com
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-canary
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: test-monochart-stable
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  type: NodePort
  ports:
  - targetPort: http
    port: 443
    protocol: TCP
    name: http
  selector:
    app: monochart
    release: test
    serve: "true"
---
# Source: monochart/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-monochart
  annotations:
    nginx.version: 1.15.3
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    component: nginx
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
      type: monochart
  minReadySeconds: 10
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 83fd7c058d482e068040736afb103e5b1bbb16cf881311a02474df6d43a4f41c
        checksum/secret: 72172972beefdfe6a6ec75751f12f82cca6cea1ec5b4d46d2ff4de7b679041d8
      labels:
        app: monochart
        release: "test"
        serve: "true"
        type: monochart
    spec:
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app: nginx-test
          maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: ScheduleAnyway
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  release: squid-proxy
              topologyKey: kubernetes.io/hostname
            weight: 100
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                release: squid-proxy
            topologyKey: kubernetes.io/hostname
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app
                  operator: In
                  values:
                  - monochart
                - key: release
                  operator: In
                  values:
                  - "test"
              topologyKey: "kubernetes.io/hostname"
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: NotIn
                values:
                - postgresql
              - key: release
                operator: NotIn
                values:
                - postgresql
            topologyKey: kubernetes.io/hostname
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - custom-worker-group
      tolerations:
      - effect: NoSchedule
        key: spotinst.io/pool
        operator: Equal
        value: custom-vng
      securityContext:
        fsGroup: 2000
        runAsGroup: 3000
        runAsUser: 1000
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        lifecycle:
          preStop:
            exec:
              command:
              - sh
              - -c
              - sleep 60
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: /var/run/datadog
          name: apmsocketpath
        - mountPath: "/tmp"
          name: ephemeral-storage
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      - hostPath:
          path: /var/run/datadog/
        name: apmsocketpath
      - name: ephemeral-storage
        ephemeral:
          volumeClaimTemplate:
            metadata:
              labels:
                type: monochart
            spec:
              accessModes: [ "ReadWriteOnce" ]
              storageClassName: "gp3"
              resources:
                requests:
                  storage: 30Gi
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
---
# Source: monochart/templates/statefulset.yaml
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
  serviceName: test-monochart  
  podManagementPolicy: Parallel
  replicas: 
  revisionHistoryLimit: 10
  template:
    metadata:
      name: test-monochart
      annotations:
        checksum/config: 593eefff05a5636c74afaa6d5be3da0e9b350532794bb6f6e3d1e352b995dc8f
        checksum/secret: acd505d4275efdcb2573ab7925f9dc5d698f61dd70d1401bb505344033934ba2
      labels:
        app: monochart
        release: "test"
        serve: "true"
    spec:
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsUser: 1000
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 10
      dnsConfig:
          options:
          - name: ndots
            value: "1"
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
                - matchExpressions:
                  - key: Name
                    operator: In
                    values:
                    - va-verity-eks--stage-vng-public
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: "/tmp"
          name: test-monochart
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default
  volumeClaimTemplates:
  - metadata:
      name: test-monochart
      labels:
        app: monochart
        chart: monochart-1.0.11
        heritage: "Helm"
        release: "test"
    spec:
      accessModes:
        - "ReadWriteOnce"
      resources:
        requests:
          storage: "30Gi"
      storageClassName: "gp3"
---
# Source: monochart/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
    ingressName: default
  name: test-monochart-default
spec:
  rules:
    - host: testme.com
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name:  test-monochart
                port:
                  name: http
---
# Source: monochart/templates/rollout.yaml
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: test-monochart
  labels:
    app: monochart
    chart: monochart-1.0.11
    heritage: "Helm"
    release: "test"
spec:
  selector:
    matchLabels:
      app: monochart
      release: test
      serve: "true"
  strategy:
    canary:
      abortScaleDownDelaySeconds: 60
      dynamicStableScale: true
      maxSurge: 10%
      maxUnavailable: 1
      stableService: test-monochart-stable
      canaryService: test-monochart-canary
      steps:
        - setWeight: 5
        - pause: {}
        - setWeight: 20
        - pause:
            duration: 10m
        - setWeight: 40
        - pause:
            duration: 10m
        - setWeight: 60
        - pause:
            duration: 10m
        - setWeight: 80
        - pause:
            duration: 10m
      analysis:
        startingStep: 1
        templates:
        - templateName: analysis-run-test
      trafficRouting:
        alb:
          ingress: test-monochart-default
          rootService: test-monochart
          servicePort: 443
  minReadySeconds: 0
  revisionHistoryLimit: 
  template:
    metadata:
      labels:
        app: monochart
        release: test
        serve: "true"
    spec:
      serviceAccountName: monochart-monochart-default
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      containers:
      - name: test
        image: nginx:1.15.3
        imagePullPolicy: IfNotPresent
        
        envFrom:
        - configMapRef:
            name: test-monochart-env-default
        - secretRef:
            name: test-monochart-env-default
        env:
          - name: INLINE_ENV_NAME
            value: "ENV_VALUE"
        
        
          - name: ENV_1
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
        
        ports:
          - name: http
            containerPort: 8080
            protocol: TCP
        volumeMounts:
        - mountPath: "/tmp"
          name: storage
        
        - mountPath: /config-default
          name: config-default-files
        - mountPath: /secret-default
          name: secret-default-files
          readOnly: true
      imagePullSecrets:
        - name: docker-secret-1
        - name: docker-secret-2
      volumes:
      - name: storage
        persistentVolumeClaim:
          claimName: test-monochart
      
      - name: config-default-files
        configMap:
          name: test-monochart-files-default
      - name: secret-default-files
        secret:
          secretName: test-monochart-files-default

NOTES:
------------------------------------
📦 monochart 1.0.11
└── 🌀 Namespace: squid
└── 🚀 Release:   test
└── 🐳 Container: nginx:1.15.3
└── 🌐 URL:       https://testme.com
------------------------------------

📚Manifests deployed:
│
├─ ✅Configmaps
│  └── ✅default
├─ ✅Crd
│  └── ✅Serviceaccount
│     └── ✅default
├─ ✅Deployment
├─ ✅Ingress
│  └── ✅default
├─ ✅Persistence
├─ ✅Rollout
├─ ✅Secrets
│  └── ✅default
├─ ✅Service
│  └── ✅canary
│  └── ✅default
│  └── ✅stable
├─ ✅Statefulset
├─ ✅Storageclass
```